### PR TITLE
#32 优化jwt token解析错误的异常提示

### DIFF
--- a/src/JWT.php
+++ b/src/JWT.php
@@ -443,8 +443,11 @@ class JWT extends AbstractJWT
         if($token == null) {
             $token = JWTUtil::getToken($this->request);
         }
-
-        return JWTUtil::getParser()->parse($token);
+        try{
+            return JWTUtil::getParser()->parse($token);
+        }catch (\Exception $e) {
+            throw new JWTException('Jwt token interpretation error. Please provide the correct jwt token and parse the error information: ' . $e->getMessage(), 400);
+        }
     }
 
     public function setScene(string $scene = 'default'): JWT


### PR DESCRIPTION
填写错误的jwt token会直接报出非JWT TOKEN的Exception，此pr优化jwt token解析的异常，解析错误会直接转为抛JWTException